### PR TITLE
fix(message): Add Placeholders into the MessagingProxy

### DIFF
--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/message/serialization/SerializedMessageBossBar.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/message/serialization/SerializedMessageBossBar.kt
@@ -1,3 +1,21 @@
+/*
+ * Vanguard
+ * Copyright (C) 2023 RedEye Technologies Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ltd.redeye.vanguard.common.message.serialization
 
 import ltd.redeye.vanguard.common.message.VanguardMessageBag

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/message/serialization/SerializedMessageSound.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/message/serialization/SerializedMessageSound.kt
@@ -1,3 +1,21 @@
+/*
+ * Vanguard
+ * Copyright (C) 2023 RedEye Technologies Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ltd.redeye.vanguard.common.message.serialization
 
 import ltd.redeye.vanguard.common.message.VanguardMessageBag

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/message/serialization/SerializedMessageTitle.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/message/serialization/SerializedMessageTitle.kt
@@ -1,3 +1,21 @@
+/*
+ * Vanguard
+ * Copyright (C) 2023 RedEye Technologies Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ltd.redeye.vanguard.common.message.serialization
 
 import ltd.redeye.vanguard.common.message.VanguardMessageBag

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/message/serialization/SerializedVanguardMessage.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/message/serialization/SerializedVanguardMessage.kt
@@ -1,3 +1,21 @@
+/*
+ * Vanguard
+ * Copyright (C) 2023 RedEye Technologies Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ltd.redeye.vanguard.common.message.serialization
 
 import ltd.redeye.vanguard.common.message.VanguardMessageBag

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/MessagingProxy.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/MessagingProxy.kt
@@ -1,3 +1,21 @@
+/*
+ * Vanguard
+ * Copyright (C) 2023 RedEye Technologies Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ltd.redeye.vanguard.common.network.messaging
 
 import ltd.redeye.vanguard.common.message.VanguardMessage

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/MessagingProxy.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/MessagingProxy.kt
@@ -2,14 +2,15 @@ package ltd.redeye.vanguard.common.network.messaging
 
 import ltd.redeye.vanguard.common.message.VanguardMessage
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
 import java.util.UUID
 
 interface MessagingProxy {
 
-    fun alertPlayer(uuid: UUID, message: VanguardMessage)
+    fun alertPlayer(uuid: UUID, message: VanguardMessage, placeholders: TagResolver?)
 
     fun kickPlayer(player: UUID, message: Component)
 
-    fun alertStaff(message: VanguardMessage)
+    fun alertStaff(message: VanguardMessage, placeholders: TagResolver?)
 
 }

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/plugin/VanguardPlugin.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/plugin/VanguardPlugin.kt
@@ -1,3 +1,21 @@
+/*
+ * Vanguard
+ * Copyright (C) 2023 RedEye Technologies Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ltd.redeye.vanguard.common.plugin
 
 import ltd.redeye.vanguard.common.command.lib.types.PlatformCommandInitializer

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/util/Permissions.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/util/Permissions.kt
@@ -1,3 +1,21 @@
+/*
+ * Vanguard
+ * Copyright (C) 2023 RedEye Technologies Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ltd.redeye.vanguard.common.util
 
 enum class Permissions {

--- a/paper/src/main/kotlin/ltd/redeye/vanguard/paper/network/PaperSingleMessagingProxy.kt
+++ b/paper/src/main/kotlin/ltd/redeye/vanguard/paper/network/PaperSingleMessagingProxy.kt
@@ -1,3 +1,21 @@
+/*
+ * Vanguard
+ * Copyright (C) 2023 RedEye Technologies Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ltd.redeye.vanguard.paper.network
 
 import ltd.redeye.vanguard.common.message.VanguardMessage

--- a/paper/src/main/kotlin/ltd/redeye/vanguard/paper/network/PaperSingleMessagingProxy.kt
+++ b/paper/src/main/kotlin/ltd/redeye/vanguard/paper/network/PaperSingleMessagingProxy.kt
@@ -29,11 +29,11 @@ import java.util.*
 /**
  * A messaging proxy for when no message broker is available
  */
-object PaperSingleMessagingProxy: MessagingProxy {
+object PaperSingleMessagingProxy : MessagingProxy {
 
     override fun alertPlayer(uuid: UUID, message: VanguardMessage, placeholders: TagResolver?) {
         val player = Bukkit.getPlayer(uuid)
-        if(player != null) {
+        if (player != null) {
             message.send(player, placeholders)
         }
     }
@@ -44,7 +44,7 @@ object PaperSingleMessagingProxy: MessagingProxy {
 
     override fun alertStaff(message: VanguardMessage, placeholders: TagResolver?) {
         Bukkit.getOnlinePlayers().forEach { player ->
-            if(player.hasPermission(Permissions.STAFF.permission())) {
+            if (player.hasPermission(Permissions.STAFF.permission())) {
                 message.send(player, placeholders)
             }
         }

--- a/paper/src/main/kotlin/ltd/redeye/vanguard/paper/network/PaperSingleMessagingProxy.kt
+++ b/paper/src/main/kotlin/ltd/redeye/vanguard/paper/network/PaperSingleMessagingProxy.kt
@@ -4,6 +4,7 @@ import ltd.redeye.vanguard.common.message.VanguardMessage
 import ltd.redeye.vanguard.common.network.messaging.MessagingProxy
 import ltd.redeye.vanguard.common.util.Permissions
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
 import org.bukkit.Bukkit
 import java.util.*
 
@@ -12,10 +13,10 @@ import java.util.*
  */
 object PaperSingleMessagingProxy: MessagingProxy {
 
-    override fun alertPlayer(uuid: UUID, message: VanguardMessage) {
+    override fun alertPlayer(uuid: UUID, message: VanguardMessage, placeholders: TagResolver?) {
         val player = Bukkit.getPlayer(uuid)
         if(player != null) {
-            message.send(player)
+            message.send(player, placeholders)
         }
     }
 
@@ -23,10 +24,10 @@ object PaperSingleMessagingProxy: MessagingProxy {
         Bukkit.getPlayer(player)?.kick(message)
     }
 
-    override fun alertStaff(message: VanguardMessage) {
+    override fun alertStaff(message: VanguardMessage, placeholders: TagResolver?) {
         Bukkit.getOnlinePlayers().forEach { player ->
             if(player.hasPermission(Permissions.STAFF.permission())) {
-                message.send(player)
+                message.send(player, placeholders)
             }
         }
     }


### PR DESCRIPTION
Adds TagResolvers into the MessagingProxy so it can be parsed by a SingleMessagingProxy

When redis is implemented the MessagingProxy will serialize in its instance, and then send the serialized versions over redis, retaining the original for sending on the sender server.