### PR TITLE
redis communication

### DIFF
--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/VanguardCore.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/VanguardCore.kt
@@ -23,7 +23,9 @@ import ltd.redeye.vanguard.common.command.lib.VanguardCommandManager
 import ltd.redeye.vanguard.common.config.ConfigManager
 import ltd.redeye.vanguard.common.config.file.MessagesConfig
 import ltd.redeye.vanguard.common.config.file.VanguardConfig
-import ltd.redeye.vanguard.common.network.messaging.MessagingProxy
+import ltd.redeye.vanguard.common.network.NetworkManager
+import ltd.redeye.vanguard.common.network.messaging.proxy.MessagingProxy
+import ltd.redeye.vanguard.common.network.messaging.proxy.RedisMessagingProxy
 import ltd.redeye.vanguard.common.player.VanguardPlayerManager
 import ltd.redeye.vanguard.common.plugin.VanguardPlugin
 import ltd.redeye.vanguard.common.punishment.VanguardPunishmentManager
@@ -69,10 +71,12 @@ class VanguardCore(private val vanguardPlugin: VanguardPlugin) {
 
     val messagingProxy = selectMessagingProxy()
 
-    // todo -> Make this check if there is another message broker set in the config
-    // todo -> such as redis. For now we will focus on using the default (single) broker
     private fun selectMessagingProxy(): MessagingProxy {
-        return vanguardPlugin.defaultMessagingProxy()
+        return if(config.network.enabled) {
+            RedisMessagingProxy(vanguardPlugin.defaultMessagingProxy())
+        } else {
+            vanguardPlugin.defaultMessagingProxy()
+        }
     }
 
 }

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/config/file/MessagesConfig.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/config/file/MessagesConfig.kt
@@ -24,6 +24,7 @@ import ltd.redeye.vanguard.common.message.VanguardMessage
 import ltd.redeye.vanguard.common.message.section.MessageBossBar
 import ltd.redeye.vanguard.common.message.section.MessageSound
 import ltd.redeye.vanguard.common.message.section.MessageTitle
+import net.kyori.adventure.bossbar.BossBar
 import org.spongepowered.configurate.objectmapping.ConfigSerializable
 import org.spongepowered.configurate.objectmapping.meta.Comment
 
@@ -34,7 +35,7 @@ data class MessagesConfig(
         chat = mutableListOf("<red>Message One", "<#00ff00><bold>Message Two", "<gradient:red:blue>Message Three"),
         "Example Actionbar",
         MessageTitle("Example Title", "Example Subtitle", 10, 10, 10),
-        MessageBossBar("Example Bossbar", "blue", "notched_20", 1.0F),
+        MessageBossBar("Example Bossbar", BossBar.Color.BLUE, BossBar.Overlay.NOTCHED_20, 1.0F),
         MessageSound("minecraft:entity.experience_orb.pickup", 1.0F, 1.0F)
     ),
 

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/message/VanguardMessage.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/message/VanguardMessage.kt
@@ -68,7 +68,7 @@ data class VanguardMessage(
         send(target.audience(), tagResolver)
     }
 
-    fun serialize(tagResolver: TagResolver): SerializedVanguardMessage {
+    fun serialize(tagResolver: TagResolver?): SerializedVanguardMessage {
 
         val chat = this.chat.orEmpty().map { parseToGson(it, tagResolver) }.toCollection(ArrayList())
 

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/message/section/MessageBossBar.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/message/section/MessageBossBar.kt
@@ -46,7 +46,7 @@ data class MessageBossBar(
         )
     }
 
-    fun serialize(tagResolver: TagResolver): SerializedMessageBossBar {
+    fun serialize(tagResolver: TagResolver?): SerializedMessageBossBar {
         return SerializedMessageBossBar(
             if(title!!.isNotEmpty()) parseToGson(title.orEmpty(), tagResolver) else "",
             progress!!,

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/message/section/MessageTitle.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/message/section/MessageTitle.kt
@@ -51,7 +51,7 @@ data class MessageTitle(
         }
     }
 
-    fun serialize(tagResolver: TagResolver): SerializedMessageTitle {
+    fun serialize(tagResolver: TagResolver?): SerializedMessageTitle {
         return SerializedMessageTitle(
             if(title!!.isNotEmpty()) parseToGson(title!!, tagResolver) else "",
             if(subtitle!!.isNotEmpty()) parseToGson(subtitle!!, tagResolver) else "",

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/network/NetworkManager.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/network/NetworkManager.kt
@@ -31,8 +31,8 @@ import kotlin.reflect.KClass
 
 class NetworkManager {
 
-    val redisson: RedissonClient
-    val gson: Gson = GsonBuilder().create()
+    private val redisson: RedissonClient
+    private val gson: Gson = GsonBuilder().create()
 
     init {
         val networkConfig = VanguardCore.instance.config.network

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/proxy/MessagingProxy.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/proxy/MessagingProxy.kt
@@ -1,0 +1,39 @@
+/*
+ * Vanguard
+ * Copyright (C) 2023 RedEye Technologies Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ltd.redeye.vanguard.common.network.messaging.proxy
+
+import ltd.redeye.vanguard.common.message.VanguardMessage
+import ltd.redeye.vanguard.common.message.serialization.SerializedVanguardMessage
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
+import java.util.UUID
+
+interface MessagingProxy {
+
+    fun alertPlayer(uuid: UUID, message: VanguardMessage, placeholders: TagResolver?): Boolean
+
+    fun kickPlayer(player: UUID, message: Component): Boolean
+
+    fun alertStaff(message: VanguardMessage, placeholders: TagResolver?)
+
+    fun alertPlayer(uuid: UUID, message: SerializedVanguardMessage)
+
+    fun alertStaff(message: SerializedVanguardMessage)
+
+}

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/proxy/RedisMessagingProxy.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/proxy/RedisMessagingProxy.kt
@@ -1,0 +1,121 @@
+/*
+ * Vanguard
+ * Copyright (C) 2023 RedEye Technologies Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ltd.redeye.vanguard.common.network.messaging.proxy
+
+import ltd.redeye.vanguard.common.message.VanguardMessage
+import ltd.redeye.vanguard.common.message.serialization.SerializedVanguardMessage
+import ltd.redeye.vanguard.common.network.NetworkManager
+import ltd.redeye.vanguard.common.network.messaging.RedisChannel
+import ltd.redeye.vanguard.common.network.messaging.proxy.internal.AlertPlayerMessage
+import ltd.redeye.vanguard.common.network.messaging.proxy.internal.AlertStaffMessage
+import ltd.redeye.vanguard.common.network.messaging.proxy.internal.KickPlayerMessage
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import org.jetbrains.annotations.ApiStatus.Internal
+import java.util.*
+import kotlin.reflect.KClass
+
+/**
+ * A messaging proxy for when Redis connectivity is enabled
+ * The RedisMessagingProxy will take serialize the messages and send them to the redis server
+ * and send to the DefaultMessagingProxy for processing on the sender server.
+ */
+class RedisMessagingProxy(private val default: MessagingProxy): MessagingProxy {
+
+    companion object {
+        const val ALERT_PLAYER_CHANNEL = "vanguard/alert/player"
+        const val KICK_PLAYER_CHANNEL = "vanguard/kick/player"
+        const val ALERT_STAFF_CHANNEL = "vanguard/alert/staff"
+    }
+
+    // We instantiate this here as we do not want it being accessed elsewhere
+    private val networkManager = NetworkManager()
+
+    private val alertPlayerChannel = registerAndListen(
+        ALERT_PLAYER_CHANNEL,
+        AlertPlayerMessage::class
+    ) { message -> default.alertPlayer(message.uuid, message.vanguardMessage) }
+
+    private val kickPlayerChannel = registerAndListen(
+        KICK_PLAYER_CHANNEL,
+        KickPlayerMessage::class
+    ) { message -> default.kickPlayer(message.uuid, GsonComponentSerializer.gson().deserialize(message.message)) }
+
+    private val alertStaffChannel = registerAndListen(
+        ALERT_STAFF_CHANNEL,
+        AlertStaffMessage::class
+    ) { message -> default.alertStaff(message.vanguardMessage) }
+
+    override fun alertPlayer(uuid: UUID, message: VanguardMessage, placeholders: TagResolver?): Boolean {
+        // Alert the player if they are on the origin server
+        if(default.alertPlayer(uuid, message, placeholders)) {
+            return true
+        }
+
+        val serialized = message.serialize(placeholders)
+        alertPlayerChannel.send(AlertPlayerMessage(uuid, serialized))
+        return true
+    }
+
+    /**
+     * This method is not public API. Please send a VanguardMessage instead using [alertPlayer]
+     */
+    @Internal
+    override fun alertPlayer(uuid: UUID, message: SerializedVanguardMessage) {
+        throw IllegalAccessException("Cannot send serialized messages to RedisMessagingProxy")
+    }
+
+    override fun kickPlayer(player: UUID, message: Component): Boolean {
+        // Could not kick the player from the origin server, send across redis
+        if(!default.kickPlayer(player, message)) {
+            val serializedMessage = GsonComponentSerializer.gson().serialize(message)
+            kickPlayerChannel.send(KickPlayerMessage(player, serializedMessage))
+        }
+        return true
+    }
+
+    override fun alertStaff(message: VanguardMessage, placeholders: TagResolver?) {
+        // Alert the staff on the origin server
+        default.alertStaff(message, placeholders)
+
+        val serialized = message.serialize(placeholders)
+        alertStaffChannel.send(AlertStaffMessage(serialized))
+    }
+
+    /**
+     * This method is not public API. Please send a VanguardMessage instead using [alertStaff]
+     */
+    @Internal
+    override fun alertStaff(message: SerializedVanguardMessage) {
+        throw IllegalAccessException("Cannot send serialized messages to RedisMessagingProxy")
+    }
+
+    /**
+     * Registers the channel and sets up a listener for the channel
+     */
+    private fun <T: Any> registerAndListen(channel: String, clazz: KClass<T>, listen: (T) -> Unit): RedisChannel<T> {
+        val redisChannel = networkManager.register(channel, clazz.java)
+        redisChannel.listen { message ->
+            listen.invoke(message.message)
+        }
+        return redisChannel
+    }
+
+}

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/proxy/RedisMessagingProxy.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/proxy/RedisMessagingProxy.kt
@@ -37,7 +37,7 @@ import kotlin.reflect.KClass
  * The RedisMessagingProxy will take serialize the messages and send them to the redis server
  * and send to the DefaultMessagingProxy for processing on the sender server.
  */
-class RedisMessagingProxy(private val default: MessagingProxy): MessagingProxy {
+class RedisMessagingProxy(private val default: MessagingProxy) : MessagingProxy {
 
     companion object {
         const val ALERT_PLAYER_CHANNEL = "vanguard/alert/player"
@@ -65,7 +65,7 @@ class RedisMessagingProxy(private val default: MessagingProxy): MessagingProxy {
 
     override fun alertPlayer(uuid: UUID, message: VanguardMessage, placeholders: TagResolver?): Boolean {
         // Alert the player if they are on the origin server
-        if(default.alertPlayer(uuid, message, placeholders)) {
+        if (default.alertPlayer(uuid, message, placeholders)) {
             return true
         }
 
@@ -84,7 +84,7 @@ class RedisMessagingProxy(private val default: MessagingProxy): MessagingProxy {
 
     override fun kickPlayer(player: UUID, message: Component): Boolean {
         // Could not kick the player from the origin server, send across redis
-        if(!default.kickPlayer(player, message)) {
+        if (!default.kickPlayer(player, message)) {
             val serializedMessage = GsonComponentSerializer.gson().serialize(message)
             kickPlayerChannel.send(KickPlayerMessage(player, serializedMessage))
         }
@@ -110,7 +110,7 @@ class RedisMessagingProxy(private val default: MessagingProxy): MessagingProxy {
     /**
      * Registers the channel and sets up a listener for the channel
      */
-    private fun <T: Any> registerAndListen(channel: String, clazz: KClass<T>, listen: (T) -> Unit): RedisChannel<T> {
+    private fun <T : Any> registerAndListen(channel: String, clazz: KClass<T>, listen: (T) -> Unit): RedisChannel<T> {
         val redisChannel = networkManager.register(channel, clazz.java)
         redisChannel.listen { message ->
             listen.invoke(message.message)

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/proxy/internal/AlertPlayerMessage.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/proxy/internal/AlertPlayerMessage.kt
@@ -16,19 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package ltd.redeye.vanguard.common.network.messaging
+package ltd.redeye.vanguard.common.network.messaging.proxy.internal
 
-import ltd.redeye.vanguard.common.message.VanguardMessage
-import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
-import java.util.UUID
+import ltd.redeye.vanguard.common.message.serialization.SerializedVanguardMessage
+import org.jetbrains.annotations.ApiStatus.Internal
+import java.util.*
 
-interface MessagingProxy {
-
-    fun alertPlayer(uuid: UUID, message: VanguardMessage, placeholders: TagResolver?)
-
-    fun kickPlayer(player: UUID, message: Component)
-
-    fun alertStaff(message: VanguardMessage, placeholders: TagResolver?)
-
-}
+@Internal
+data class AlertPlayerMessage(val uuid: UUID, val vanguardMessage: SerializedVanguardMessage)

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/proxy/internal/AlertStaffMessage.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/proxy/internal/AlertStaffMessage.kt
@@ -1,0 +1,25 @@
+/*
+ * Vanguard
+ * Copyright (C) 2023 RedEye Technologies Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ltd.redeye.vanguard.common.network.messaging.proxy.internal
+
+import ltd.redeye.vanguard.common.message.serialization.SerializedVanguardMessage
+import org.jetbrains.annotations.ApiStatus.Internal
+
+@Internal
+data class AlertStaffMessage(val vanguardMessage: SerializedVanguardMessage)

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/proxy/internal/KickPlayerMessage.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/network/messaging/proxy/internal/KickPlayerMessage.kt
@@ -1,0 +1,25 @@
+/*
+ * Vanguard
+ * Copyright (C) 2023 RedEye Technologies Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ltd.redeye.vanguard.common.network.messaging.proxy.internal
+
+import org.jetbrains.annotations.ApiStatus.Internal
+import java.util.*
+
+@Internal
+data class KickPlayerMessage(val uuid: UUID, val message: String)

--- a/common/src/main/kotlin/ltd/redeye/vanguard/common/plugin/VanguardPlugin.kt
+++ b/common/src/main/kotlin/ltd/redeye/vanguard/common/plugin/VanguardPlugin.kt
@@ -19,7 +19,7 @@
 package ltd.redeye.vanguard.common.plugin
 
 import ltd.redeye.vanguard.common.command.lib.types.PlatformCommandInitializer
-import ltd.redeye.vanguard.common.network.messaging.MessagingProxy
+import ltd.redeye.vanguard.common.network.messaging.proxy.MessagingProxy
 import ltd.redeye.vanguard.common.player.VanguardPlayerAdapter
 
 /**
@@ -34,6 +34,5 @@ interface VanguardPlugin {
     fun dataFolder(): java.io.File
     fun createPlatformCommandInitializer(): PlatformCommandInitializer
     fun defaultMessagingProxy(): MessagingProxy
-    fun createRedisMessagingProxy(): MessagingProxy
 
 }

--- a/paper/src/main/kotlin/ltd/redeye/vanguard/paper/VanguardPlugin.kt
+++ b/paper/src/main/kotlin/ltd/redeye/vanguard/paper/VanguardPlugin.kt
@@ -20,7 +20,7 @@ package ltd.redeye.vanguard.paper
 
 import ltd.redeye.vanguard.common.VanguardCore
 import ltd.redeye.vanguard.common.command.lib.types.PlatformCommandInitializer
-import ltd.redeye.vanguard.common.network.messaging.MessagingProxy
+import ltd.redeye.vanguard.common.network.messaging.proxy.MessagingProxy
 import ltd.redeye.vanguard.common.player.VanguardPlayerAdapter
 import ltd.redeye.vanguard.common.plugin.VanguardPlugin
 import ltd.redeye.vanguard.paper.adapter.PaperVanguardPlayerAdapter
@@ -66,10 +66,6 @@ class VanguardPlugin : JavaPlugin(), VanguardPlugin {
 
     override fun defaultMessagingProxy(): MessagingProxy {
         return PaperSingleMessagingProxy
-    }
-
-    override fun createRedisMessagingProxy(): MessagingProxy {
-        TODO("Not yet implemented")
     }
 
 }

--- a/paper/src/main/kotlin/ltd/redeye/vanguard/paper/network/PaperSingleMessagingProxy.kt
+++ b/paper/src/main/kotlin/ltd/redeye/vanguard/paper/network/PaperSingleMessagingProxy.kt
@@ -19,7 +19,8 @@
 package ltd.redeye.vanguard.paper.network
 
 import ltd.redeye.vanguard.common.message.VanguardMessage
-import ltd.redeye.vanguard.common.network.messaging.MessagingProxy
+import ltd.redeye.vanguard.common.message.serialization.SerializedVanguardMessage
+import ltd.redeye.vanguard.common.network.messaging.proxy.MessagingProxy
 import ltd.redeye.vanguard.common.util.Permissions
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
@@ -31,15 +32,26 @@ import java.util.*
  */
 object PaperSingleMessagingProxy : MessagingProxy {
 
-    override fun alertPlayer(uuid: UUID, message: VanguardMessage, placeholders: TagResolver?) {
+    override fun alertPlayer(uuid: UUID, message: VanguardMessage, placeholders: TagResolver?): Boolean {
         val player = Bukkit.getPlayer(uuid)
         if (player != null) {
             message.send(player, placeholders)
+            return true
         }
+        return false
     }
 
-    override fun kickPlayer(player: UUID, message: Component) {
-        Bukkit.getPlayer(player)?.kick(message)
+    override fun alertPlayer(uuid: UUID, message: SerializedVanguardMessage) {
+        TODO("Not yet implemented")
+    }
+
+    override fun kickPlayer(player: UUID, message: Component): Boolean {
+        val onlinePlayer = Bukkit.getPlayer(player)
+        if (onlinePlayer != null) {
+            onlinePlayer.kick(message)
+            return true
+        }
+        return false
     }
 
     override fun alertStaff(message: VanguardMessage, placeholders: TagResolver?) {
@@ -48,6 +60,10 @@ object PaperSingleMessagingProxy : MessagingProxy {
                 message.send(player, placeholders)
             }
         }
+    }
+
+    override fun alertStaff(message: SerializedVanguardMessage) {
+        TODO("Not yet implemented")
     }
 
 }


### PR DESCRIPTION
This PR adds in Redis communications onto Vanguard. Where it can, it will first dispatch over the servers' default MessagingProxy to reduce redis calls if possible.

This also fixes a small issue with a configuration from the last PR with SerializedVanguardMessage.